### PR TITLE
Add JUnit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ By default the program reads `lesmiserables.txt` from `src/main/resources` and p
 Execution time: XXXX milliseconds
 ```
 
+## Tests
+
+JUnit tests validate the `MapTask`, `ReduceTask` and `Splitter` classes.
+Run them with:
+
+```bash
+mvn test
+```
+
 ## License
 
 This project is distributed under the MIT License. See the [LICENSE](LICENSE) file for details.

--- a/pom.xml
+++ b/pom.xml
@@ -4,6 +4,15 @@
   <artifactId>ProjetInfo731</artifactId>
   <version>1.0-SNAPSHOT</version>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.9.2</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
@@ -15,6 +24,14 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.0.0</version>
+        <configuration>
+          <useModulePath>false</useModulePath>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/src/test/java/MapTaskTest.java
+++ b/src/test/java/MapTaskTest.java
@@ -1,0 +1,27 @@
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import java.util.*;
+
+public class MapTaskTest {
+    @Test
+    public void testExecuteCountsWords() {
+        MapTask mapTask = new MapTask();
+        Map<String, Integer> result = mapTask.execute("Hello world Hello");
+
+        Map<String, Integer> expected = new HashMap<>();
+        expected.put("Hello", 2);
+        expected.put("world", 1);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testExecuteRemovesPunctuation() {
+        MapTask mapTask = new MapTask();
+        Map<String, Integer> result = mapTask.execute("Bonjour, monde! Bonjour?");
+
+        Map<String, Integer> expected = new HashMap<>();
+        expected.put("Bonjour", 2);
+        expected.put("monde", 1);
+        assertEquals(expected, result);
+    }
+}

--- a/src/test/java/ReduceTaskTest.java
+++ b/src/test/java/ReduceTaskTest.java
@@ -1,0 +1,18 @@
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import java.util.*;
+
+public class ReduceTaskTest {
+    @Test
+    public void testExecuteReturnsSameCounts() {
+        Map<String, Integer> partial = new HashMap<>();
+        partial.put("a", 1);
+        partial.put("b", 2);
+
+        ReduceTask reduceTask = new ReduceTask();
+        Map<String, Integer> result = reduceTask.execute(partial);
+
+        assertEquals(partial, result);
+        assertNotSame(partial, result);
+    }
+}

--- a/src/test/java/SplitterTest.java
+++ b/src/test/java/SplitterTest.java
@@ -1,0 +1,27 @@
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import java.util.*;
+import java.io.*;
+
+public class SplitterTest {
+    @Test
+    public void testSplitTextDividesFile() throws Exception {
+        ArrayList<String> blocks = Splitter.splitText("discours.txt", 3);
+        assertEquals(3, blocks.size());
+
+        StringBuilder expected = new StringBuilder();
+        try (BufferedReader br = new BufferedReader(new FileReader("src/main/resources/discours.txt"))) {
+            String line;
+            while ((line = br.readLine()) != null) {
+                expected.append(line).append(" ");
+            }
+        }
+
+        StringBuilder reconstructed = new StringBuilder();
+        for (String block : blocks) {
+            reconstructed.append(block);
+        }
+
+        assertEquals(expected.toString(), reconstructed.toString());
+    }
+}


### PR DESCRIPTION
## Summary
- add JUnit Jupiter dependency and Surefire plugin
- create unit tests for MapTask, ReduceTask and Splitter
- document test execution in README

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847dc9401a88330a15fa6d7b104c0f2